### PR TITLE
add output_directory and citrus-config.toml file support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ clap = "3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+toml = "0.8.13"


### PR DESCRIPTION
This PR closes Issue #1

Added `citrus-config.toml` file support. `citrus-cli` now searches for a config file called `citrus-config.toml` in order to determine the output directory for files. `citrus-cli` needs to be run in the same directory as `citrus-config.toml` (preferably placed at your project root) in order to locate your desired output directory. You can create this file by creating a file called `citrus-config.toml`. The file should look like this:

```toml
[config]
task_directory = "path/to/desired/task/output/directory"
```

`citrus-cli` will throw an error when this file cannot be found.